### PR TITLE
allow setting up multiple databases in the same postgres instance

### DIFF
--- a/gcloud_postgres/main.tf
+++ b/gcloud_postgres/main.tf
@@ -59,7 +59,8 @@ resource "google_sql_user" "users_readonly" {
 }
 
 resource "google_sql_database" "database" {
-  name      = var.database_name
+  count     = length(var.database_names)
+  name      = var.database_names[count.index]
   instance  = google_sql_database_instance.db.name
   charset   = "UTF8"
   collation = "en_US.UTF8"

--- a/gcloud_postgres/variables.tf
+++ b/gcloud_postgres/variables.tf
@@ -1,22 +1,23 @@
 variable "database_instance_name" {
-  description = "Name for kpi database instance in GCP."
+  description = "Name for database instance in GCP."
 }
 
-variable "database_name" {
-  description = "Name for kpi database in GCP."
+variable "database_names" {
+  type        = list(string)
+  description = "Name for databases in GCP."
 }
 
 variable "database_connection_name" {
-  description = "Name for kpi database connection in GCP."
+  description = "Name for database connection in GCP."
 }
 
 variable "database_region" {
-  description = "Region for kpi database."
+  description = "Region for database."
 }
 
 variable "database_tier" {
   default     = "db-f1-micro"
-  description = "Tier for kpi database. See https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  description = "Tier for database. See https://cloud.google.com/sql/pricing#2nd-gen-pricing"
 }
 
 variable "database_password_postgres" {

--- a/gcloud_postgres/variables.tf
+++ b/gcloud_postgres/variables.tf
@@ -1,49 +1,60 @@
 variable "database_instance_name" {
   description = "Name for database instance in GCP."
+  type        = string
 }
 
 variable "database_names" {
-  type        = list(string)
   description = "Name for databases in GCP."
+  type        = list(string)
 }
 
 variable "database_connection_name" {
   description = "Name for database connection in GCP."
+  type        = string
 }
 
 variable "database_region" {
   description = "Region for database."
+  type        = string
 }
 
 variable "database_tier" {
   default     = "db-f1-micro"
   description = "Tier for database. See https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  type        = string
 }
 
 variable "database_password_postgres" {
   description = "Password for default postgres database user."
+  type        = string
 }
+
 variable "database_username_default" {
   description = "Username for default database user."
+  type        = string
 }
 
 variable "database_password_default" {
   description = "Username for default database user."
+  type        = string
 }
 
 variable "database_username_readonly" {
   description = "Username for readonly database user."
+  type        = string
 }
 
 variable "database_password_readonly" {
   description = "Password for readonly database user."
+  type        = string
 }
 
 variable "database_private_network" {
   description = "The name or self_link of the Google Compute Engine private network to which the database is connected."
+  type        = string
 }
 
 variable "private_ip_address_range" {
-  type        = string
   description = "Name of private ip address range from gcloud"
+  type        = string
 }


### PR DESCRIPTION
We need another database for hydra, so I made some changes to be able to use the same instance. Successfully tested on dev environment.